### PR TITLE
Missing new line at printing "In Termux Without root ;) Cool"

### DIFF
--- a/kalinethunter.sh
+++ b/kalinethunter.sh
@@ -229,7 +229,7 @@ if [[ ! -z $1 ]]; then
 fi
 
 printf "\n${yellow} You are going to install Kali Nethunter"
-printf "\n In Termux Without Root ;) Cool"
+printf "\n In Termux Without Root ;) Cool\n\n"
 
 pre_cleanup
 checksysinfo

--- a/kalinethunter.sh
+++ b/kalinethunter.sh
@@ -116,7 +116,7 @@ getsha() {
 # Utility function to check integrity
 checkintegrity() {
 	printf "\n${blue} [*] Checking integrity of file..."
-	prinf "\n [*] The script will immediately terminate in case of integrity failure"
+	printf "\n [*] The script will immediately terminate in case of integrity failure"
 	printf "${reset}\n"
 	sha512sum -c $rootfs.sha512sum || \\
         {


### PR DESCRIPTION
## Missing new line at printing "In Termux Without root ;) Cool" and typo prinf 
_Literally just added 5 characters_ 

Added "`/n/n`" to line `232`
_i.e._ 
> Changed `printf "\n In Termux Without Root ;) Cool"` to `printf "\n In Termux Without Root ;) Cool\n\n"`

**Without fix:**
<img width="892" height="224" alt="Image showing missing new line" src="https://github.com/user-attachments/assets/930a425c-413f-4f8b-9d62-2557ea71022e" />

**With fix:**
<img width="524" height="383" alt="Image showing proposed fixed new line" src="https://github.com/user-attachments/assets/ce76fd66-b00b-4314-9311-fb788a8bfc5d" />
